### PR TITLE
added slack support

### DIFF
--- a/lib/atom_pair.coffee
+++ b/lib/atom_pair.coffee
@@ -10,6 +10,7 @@ _ = require 'underscore'
 chunkString = require './helpers/chunk-string'
 
 HipChatInvite = require './modules/hipchat_invite'
+SlackInvite = require './modules/slack_invite'
 Marker = require './modules/marker'
 GrammarSync = require './modules/grammar_sync'
 AtomPairConfig = require './modules/atom_pair_config'
@@ -40,6 +41,10 @@ module.exports = AtomPair =
       type: 'string'
       description: 'Pusher App Secret'
       default: '4bf35003e819bb138249'
+    slack_url:
+      type: 'string'
+      description: 'WebHook URL for Slack Incoming Webhook Integration'
+      default: ''
 
   activate: (state) ->
     # Events subscribed to in atom's system can be easily cleaned up with a CompositeDisposable
@@ -51,6 +56,7 @@ module.exports = AtomPair =
     @subscriptions.add atom.commands.add 'atom-workspace', 'AtomPair:join pairing session': => @joinSession()
     @subscriptions.add atom.commands.add 'atom-workspace', 'AtomPair:set configuration keys': => @setConfig()
     @subscriptions.add atom.commands.add 'atom-workspace', 'AtomPair:invite over hipchat': => @inviteOverHipChat()
+    @subscriptions.add atom.commands.add 'atom-workspace', 'AtomPair:invite over slack': => @inviteOverSlack()
     @subscriptions.add atom.commands.add 'atom-workspace', 'AtomPair:custom-paste': => @customPaste()
 
     atom.commands.add 'atom-workspace', 'AtomPair:hide views': => @hidePanel()
@@ -60,7 +66,7 @@ module.exports = AtomPair =
     @friendColours = []
     @timeouts = []
     @events = []
-    _.extend(@, HipChatInvite, Marker, GrammarSync, AtomPairConfig, CustomPaste)
+    _.extend(@, HipChatInvite, SlackInvite, Marker, GrammarSync, AtomPairConfig, CustomPaste)
 
   disconnect: ->
     @pusher.disconnect()
@@ -149,7 +155,6 @@ module.exports = AtomPair =
     @triggerPush = true
 
   startPairing: ->
-
     @triggerPush = true
     buffer = @buffer = @editor.buffer
 

--- a/lib/modules/atom_pair_config.coffee
+++ b/lib/modules/atom_pair_config.coffee
@@ -7,7 +7,9 @@ module.exports = AtomPairConfig =
     @app_secret = atom.config.get 'atom-pair.pusher_app_secret'
     @hc_key = atom.config.get 'atom-pair.hipchat_token'
     @room_name = atom.config.get 'atom-pair.hipchat_room_name'
+    @slack_url = atom.config.get 'atom-pair.slack_url'
 
   missingPusherKeys: -> _.any([@app_key, @app_secret], @missing)
   missingHipChatKeys: -> _.any([@hc_key, @room_name], @missing)
+  missingSlackWebHook: -> _.any([@slack_url], @missing)
   missing: (key) -> key is '' || typeof(key) is "undefined"

--- a/lib/modules/slack_invite.coffee
+++ b/lib/modules/slack_invite.coffee
@@ -1,0 +1,43 @@
+InputView = require '../views/input-view'
+AlertView = require '../views/alert-view'
+Slack = require 'slack-node'
+_ = require 'underscore'
+
+module.exports = SlackInvite =
+
+  inviteOverSlack: ->
+    @getKeysFromConfig()
+
+    if @missingPusherKeys()
+      alertView = new AlertView "Please set your Pusher keys."
+      atom.workspace.addModalPanel(item: alertView, visible: true)
+    else if @missingSlackWebHook()
+      alertView = new AlertView "Please set your Slack Incoming WebHook"
+      atom.workspace.addModalPanel(item: alertView, visible: true)
+    else
+      inviteView = new InputView("Please enter the Slack name of your pair partner (or channel name):")
+      invitePanel = atom.workspace.addModalPanel(item: inviteView, visible: true)
+      inviteView.on 'core:confirm', =>
+        messageRcpt = inviteView.miniEditor.getText()
+        @sendSlackMessageTo(messageRcpt)
+        invitePanel.hide()
+
+  sendSlackMessageTo: (messageRcpt) ->
+    #prepare the slack stuff
+    slack = new Slack()
+    slack.setWebhook @slack_url
+    #generate the sessionid
+    @generateSessionId()
+    #create params
+    params =
+      text: "Hello there #{messageRcpt}. You have been invited to a pairing session. If you haven't installed the AtomPair plugin, type \`apm install atom-pair\` into your terminal. Go onto Atom, hit 'Join a pairing session', and enter this string: #{@sessionId}"
+      channel: messageRcpt
+      username: 'AtomPair'
+      icon_emoji: ':couple_with_heart:'
+    #send a message to the user
+    slack.webhook params, (err, response) =>
+      alertView = new AlertView "#{messageRcpt} has been sent an invitation. Hold tight!"
+      atom.workspace.addModalPanel(item: alertView, visible: true)
+      @markerColour = @colours[0]
+      @pairingSetup()
+      return

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "jquery": "^2.1.3",
     "node-hipchat": "^0.4.5",
     "randomstring": "^1.0.3",
+    "slack-node": "^0.1.0",
     "space-pen": "^5.0.1",
     "underscore": "^1.7.0"
   }


### PR DESCRIPTION
I've added slack support in this pull request.  I mostly copied from what you had for hipchat with a few exceptions:
1. I'm only supporting a single recipient (or channel) instead of multiple like in hipchat
2. At the end of the hipchat file, it tries to call `@startPairing()` but from my brief testing, this fails because `@editor` isn't defined yet.  I've done something slightly different and essentially made it start a session like it's done when the user starts a session from the menu.  I've tested this and it works for me, so hopefully that's OK.

Love the package, and I look forward to using it with Slack soon. :)
