### PR TITLE
Fixed issue with escape key taking precedence by making views listen to ...

### DIFF
--- a/keymaps/atom_pair.cson
+++ b/keymaps/atom_pair.cson
@@ -7,8 +7,6 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'atom-workspace':
-  'escape': 'AtomPair:hide views'
 'atom-text-editor#AtomPair':
   'ctrl-v': 'AtomPair:custom-paste'
   'cmd-v': 'AtomPair:custom-paste'

--- a/lib/modules/hipchat_invite.coffee
+++ b/lib/modules/hipchat_invite.coffee
@@ -9,18 +9,16 @@ module.exports = HipChatInvite =
     @getKeysFromConfig()
 
     if @missingPusherKeys()
-      alertView = new AlertView "Please set your Pusher keys."
-      atom.workspace.addModalPanel(item: alertView, visible: true)
+      new AlertView "Please set your Pusher keys."
     else if @missingHipChatKeys()
-      alertView = new AlertView "Please set your HipChat keys."
-      atom.workspace.addModalPanel(item: alertView, visible: true)
+      new AlertView "Please set your HipChat keys."
     else
       inviteView = new InputView("Please enter the HipChat mention name of your pair partner:")
-      invitePanel = atom.workspace.addModalPanel(item: inviteView, visible: true)
+      inviteView.miniEditor.focus()
       inviteView.on 'core:confirm', =>
         mentionNames = inviteView.miniEditor.getText()
         @sendHipChatMessageTo(mentionNames)
-        invitePanel.hide()
+        inviteView.panel.hide()
 
   sendHipChatMessageTo: (mentionNames) ->
 
@@ -39,7 +37,6 @@ module.exports = HipChatInvite =
         room_id = _.findWhere(data.rooms, {name: @room_name}).room_id
       catch error
         keyErrorView = new AlertView "Something went wrong. Please check your HipChat keys."
-        atom.workspace.addModalPanel(item: keyErrorView, visible: true)
         return
 
       params =
@@ -50,6 +47,5 @@ module.exports = HipChatInvite =
 
       hc_client.postMessage params, (data) =>
         if collaboratorsArray.length > 1 then verb = "have" else verb = "has"
-        alertView = new AlertView "#{collaboratorsString} #{verb} been sent an invitation. Hold tight!"
-        atom.workspace.addModalPanel(item: alertView, visible: true)
+        new AlertView "#{collaboratorsString} #{verb} been sent an invitation. Hold tight!"
         @startPairing()

--- a/lib/modules/slack_invite.coffee
+++ b/lib/modules/slack_invite.coffee
@@ -9,18 +9,16 @@ module.exports = SlackInvite =
     @getKeysFromConfig()
 
     if @missingPusherKeys()
-      alertView = new AlertView "Please set your Pusher keys."
-      atom.workspace.addModalPanel(item: alertView, visible: true)
+      new AlertView "Please set your Pusher keys."
     else if @missingSlackWebHook()
-      alertView = new AlertView "Please set your Slack Incoming WebHook"
-      atom.workspace.addModalPanel(item: alertView, visible: true)
+      new AlertView "Please set your Slack Incoming WebHook"
     else
       inviteView = new InputView("Please enter the Slack name of your pair partner (or channel name):")
-      invitePanel = atom.workspace.addModalPanel(item: inviteView, visible: true)
+      inviteView.miniEditor.focus()
       inviteView.on 'core:confirm', =>
         messageRcpt = inviteView.miniEditor.getText()
         @sendSlackMessageTo(messageRcpt)
-        invitePanel.hide()
+        invitePanel.panel.hide()
 
   sendSlackMessageTo: (messageRcpt) ->
     #prepare the slack stuff
@@ -36,8 +34,7 @@ module.exports = SlackInvite =
       icon_emoji: ':couple_with_heart:'
     #send a message to the user
     slack.webhook params, (err, response) =>
-      alertView = new AlertView "#{messageRcpt} has been sent an invitation. Hold tight!"
-      atom.workspace.addModalPanel(item: alertView, visible: true)
+      new AlertView "#{messageRcpt} has been sent an invitation. Hold tight!"
       @markerColour = @colours[0]
       @pairingSetup()
       return

--- a/lib/views/alert-view.coffee
+++ b/lib/views/alert-view.coffee
@@ -1,7 +1,8 @@
-{View} = require 'space-pen'
-{TextEditorView} = require 'atom-space-pen-views'
+AtomPairView = require './atom-pair-view'
 
 module.exports =
-class AlertView extends View
+class AlertView extends AtomPairView
 
-  @content: (message)-> @div => @div message
+  @content: (message)->
+    @div tabindex: 1, =>
+      @div message

--- a/lib/views/atom-pair-view.coffee
+++ b/lib/views/atom-pair-view.coffee
@@ -1,0 +1,12 @@
+{View} = require 'space-pen'
+_ = require 'underscore'
+
+module.exports =
+  class AtomPairView extends View
+
+    initialize: ->
+      @panel ?= atom.workspace.addModalPanel(item: @, visible: true)
+      @.focus()
+      @.on 'core:cancel', =>
+        @panel.hide()
+        @.focusout()

--- a/lib/views/input-view.coffee
+++ b/lib/views/input-view.coffee
@@ -1,8 +1,8 @@
-{View} = require 'space-pen'
+AtomPairView = require './atom-pair-view'
 {TextEditorView} = require 'atom-space-pen-views'
 
 module.exports =
-class InputView extends View
+class InputView extends AtomPairView
 
   @content: (label)->
     @div =>

--- a/lib/views/start-view.coffee
+++ b/lib/views/start-view.coffee
@@ -1,8 +1,7 @@
-{View} = require 'space-pen'
-{TextEditorView} = require 'atom-space-pen-views'
+AtomPairView = require './atom-pair-view'
 
 module.exports =
-class StartView extends View
+class StartView extends AtomPairView
 
   @content: (sessionId)->
     @div class: 'session-id', tabindex: 1, =>


### PR DESCRIPTION
...'core:cancel'. All views now inherit from AtomPairView, which also adds the item to modal panel. Resolves #28
