### PR TITLE
Ensure there are no references to a destroyed editor. Resolves #1

### DIFF
--- a/lib/atom_pair.coffee
+++ b/lib/atom_pair.coffee
@@ -84,6 +84,7 @@ module.exports = AtomPair =
     @editorListeners.dispose()
     _.each @friendColours, (colour) => @clearMarkers(colour)
     atom.views.getView(@editor).removeAttribute('id')
+    @editor = @buffer = null
     @markerColour = null
 
   copyId: -> atom.clipboard.write(@sessionId)


### PR DESCRIPTION
Resolves issues where people have seen errors such as 'This TextEditor Has Been Destroyed'. If an editor _is_ destroyed, this amendment makes sure there are no references to that editor in the package.
