### PR TITLE
Replaced jquery events with atom command registry events. Resolves #46 and #45

### DIFF
--- a/lib/atom_pair.coffee
+++ b/lib/atom_pair.coffee
@@ -98,12 +98,11 @@ module.exports = AtomPair =
     joinView = new InputView("Enter the session ID here:")
     joinView.miniEditor.focus()
 
-    joinView.on 'core:confirm', =>
+    atom.commands.add joinView.element, 'core:confirm': =>
       @sessionId = joinView.miniEditor.getText()
       keys = @sessionId.split("-")
       [@app_key, @app_secret] = [keys[0], keys[1]]
       joinView.panel.hide()
-
       atom.workspace.open().then => @pairingSetup() #starts a new tab to join pairing session
 
   startSession: ->

--- a/lib/modules/hipchat_invite.coffee
+++ b/lib/modules/hipchat_invite.coffee
@@ -15,7 +15,7 @@ module.exports = HipChatInvite =
     else
       inviteView = new InputView("Please enter the HipChat mention name of your pair partner:")
       inviteView.miniEditor.focus()
-      inviteView.on 'core:confirm', =>
+      atom.commands.add inviteView.element, 'core:confirm': =>
         mentionNames = inviteView.miniEditor.getText()
         @sendHipChatMessageTo(mentionNames)
         inviteView.panel.hide()

--- a/lib/modules/slack_invite.coffee
+++ b/lib/modules/slack_invite.coffee
@@ -15,7 +15,7 @@ module.exports = SlackInvite =
     else
       inviteView = new InputView("Please enter the Slack name of your pair partner (or channel name):")
       inviteView.miniEditor.focus()
-      inviteView.on 'core:confirm', =>
+      atom.commands.add inviteView.element, 'core:confirm': =>
         messageRcpt = inviteView.miniEditor.getText()
         @sendSlackMessageTo(messageRcpt)
         inviteView.panel.hide()

--- a/lib/views/atom-pair-view.coffee
+++ b/lib/views/atom-pair-view.coffee
@@ -7,7 +7,7 @@ module.exports =
     initialize: ->
       @panel ?= atom.workspace.addModalPanel(item: @, visible: true)
       @.focus()
-      @.on 'core:cancel', => @hideView()
+      atom.commands.add(@element, 'core:cancel', => @hideView())
 
     hideView: ->
       @panel.hide()


### PR DESCRIPTION
jQuery::trigger and jQuery::on have been deprecated. The package now uses Atom's command registry to listen for events on views.
