### PR TITLE
Add invite over Flowdock

### DIFF
--- a/lib/atom_pair.coffee
+++ b/lib/atom_pair.coffee
@@ -10,6 +10,7 @@ randomstring = null
 _ = null
 chunkString = null
 
+FlowdockInvite = null
 HipChatInvite = null
 SlackInvite = null
 AtomPairConfig = null
@@ -22,6 +23,10 @@ module.exports = AtomPair =
   subscriptions: null
 
   config:
+    flowdock_key:
+      type: 'string'
+      description: 'Flowdock API token'
+      default: ''
     hipchat_token:
       type: 'string'
       description: 'HipChat admin token (optional)'
@@ -52,6 +57,7 @@ module.exports = AtomPair =
     randomstring = require 'randomstring'
     _ = require 'underscore'
 
+    FlowdockInvite = require './modules/flowdock_invite'
     HipChatInvite = require './modules/hipchat_invite'
     SlackInvite = require './modules/slack_invite'
 
@@ -63,13 +69,14 @@ module.exports = AtomPair =
     # Register command that toggles this view
     @subscriptions.add atom.commands.add 'atom-workspace', 'AtomPair:start new pairing session': => @startSession()
     @subscriptions.add atom.commands.add 'atom-workspace', 'AtomPair:join pairing session': => @joinSession()
+    @subscriptions.add atom.commands.add 'atom-workspace', 'AtomPair:invite over flowdock': => @inviteOverFlowdock()
     @subscriptions.add atom.commands.add 'atom-workspace', 'AtomPair:invite over hipchat': => @inviteOverHipChat()
     @subscriptions.add atom.commands.add 'atom-workspace', 'AtomPair:invite over slack': => @inviteOverSlack()
 
 
     @colours = require('./helpers/colour-list')
     @friendColours = []
-    _.extend(@, HipChatInvite, SlackInvite, AtomPairConfig)
+    _.extend(@, FlowdockInvite, HipChatInvite, SlackInvite, AtomPairConfig)
 
     @triggerPush = @engageTabListener = true
 

--- a/lib/modules/atom_pair_config.coffee
+++ b/lib/modules/atom_pair_config.coffee
@@ -5,11 +5,13 @@ module.exports = AtomPairConfig =
   getKeysFromConfig: ->
     @app_key = atom.config.get 'atom-pair.pusher_app_key'
     @app_secret = atom.config.get 'atom-pair.pusher_app_secret'
+    @flowdock_key = atom.config.get 'atom-pair.flowdock_key'
     @hc_key = atom.config.get 'atom-pair.hipchat_token'
     @room_name = atom.config.get 'atom-pair.hipchat_room_name'
     @slack_url = atom.config.get 'atom-pair.slack_url'
 
   missingPusherKeys: -> _.any([@app_key, @app_secret], @missing)
+  missingFlowdockKey: -> _.any([@flowdock_key], @missing)
   missingHipChatKeys: -> _.any([@hc_key, @room_name], @missing)
   missingSlackWebHook: -> _.any([@slack_url], @missing)
   missing: (key) -> key is '' || typeof(key) is "undefined"

--- a/lib/modules/flowdock_invite.coffee
+++ b/lib/modules/flowdock_invite.coffee
@@ -1,0 +1,86 @@
+InputView = require '../views/input-view'
+Flowdock = require 'flowdock'
+_ = require 'underscore'
+
+module.exports = FlowdockInvite =
+
+  inviteOverFlowdock: ->
+    @getKeysFromConfig()
+
+    if @missingPusherKeys()
+      atom.notifications.addError("Please set your Pusher keys.")
+    else if @missingFlowdockKey()
+      atom.notifications.addError("Please set your Flowdock API key.")
+    else
+      inviteView = new InputView("Please enter the Flowdock name of your pair partner (or flow name):")
+      inviteView.miniEditor.focus()
+      atom.commands.add inviteView.element, 'core:confirm': =>
+        messageRcpt = inviteView.miniEditor.getText()
+        inviteView.panel.hide()
+        @sendFlowdockMessageTo(messageRcpt)
+
+
+  sendFlowdockMessageTo: (messageRcpt) ->
+    if _.isEmpty messageRcpt then return
+
+    try
+      @session = new Flowdock.Session(@flowdock_key)
+      @session.on 'error', () -> _.noop  #prevent errors from affecting Atom
+    catch error
+      atom.notifications.addError("Could not connect to Flowdock. Please check your API key.")
+      return
+
+    @generateSessionId()
+
+    inviteText = "Hello there #{messageRcpt}. You have been invited to a pairing session. If you haven't installed the AtomPair plugin, type \`apm install atom-pair\` into your terminal. Go onto Atom, hit 'Join a pairing session', and enter this string: `#{@sessionId}`"
+
+    recipient = @getRecipient(messageRcpt) # THIS DOES NOT WORK; ASYNC PROGRAMMING FAIL. Need to wait for @getRecipient to return. How?
+
+    if recipient.type is 'user'
+      # send a message to the user
+      @session.privateMessage recipient.id, inviteText, (err, message, res) =>
+        console.log 'Sending invite...'
+        atom.notifications.addInfo("#{messageRcpt} has been sent an invitation. Hold tight!")
+        @markerColour = @colours[0]
+        @pairingSetup()
+        return
+
+    if recipient.type is 'flow'
+      # send a message to the flow
+      @session.message recipient.id, inviteText, (err, message, res) =>
+        atom.notifications.addInfo("#{messageRcpt} has been sent an invitation. Hold tight!")
+        @markerColour = @colours[0]
+        @pairingSetup()
+        return
+
+
+  getRecipient: (messageRcpt) ->
+    isNickLookup = messageRcpt.charAt(0) is '@'
+    rcptAlias = if isNickLookup then messageRcpt.slice(1).toUpperCase() else messageRcpt.toUpperCase()
+
+    # Can't be sure if we're inviting a user or a flow. Try users then flows.
+    @session.get '/users', {}, (err, message, res) ->
+      if err then atom.notifications.addError("Could not fetch Flowdock users.")
+
+      users = res.body
+      userRcpt = _.find users, (user) ->
+        if isNickLookup
+          return rcptAlias is user.nick.toUpperCase()
+        else
+          return rcptAlias is user.nick.toUpperCase() or rcptAlias is user.name.toUpperCase()
+
+      if userRcpt
+        console.log userRcpt
+        return {type: 'user', id: userRcpt.id}
+
+    # check flows if we're still emptyhanded and not searching nicks
+    if !isNickLookup
+      @session.flows (err, flows) ->
+        flowRcpt = _.find flows, (flow) ->
+          rcptAlias is flow.name.toUpperCase() or rcptAlias is flow.parameterized_name.toUpperCase()
+
+        if flowRcpt
+          console.log flowRcpt
+          return {type: 'flow', id: flowRcpt.id}
+
+        atom.notifications.addError("Could not find a flow or user matching #{messageRcpt}.")

--- a/menus/atom-pair.json
+++ b/menus/atom-pair.json
@@ -18,6 +18,10 @@
             "label": "Invite",
             "submenu": [
               {
+                "label": "Invite Over Flowdock",
+                "command": "AtomPair:invite over flowdock"
+              },
+              {
                 "label": "Invite Over HipChat",
                 "command": "AtomPair:invite over hipchat"
               },

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "atom-space-pen-views": "^2.0.3",
+    "flowdock": "^0.9.0",
     "jquery": "^2.1.3",
     "node-hipchat": "^0.4.5",
     "randomstring": "^1.0.3",


### PR DESCRIPTION
All the action is in `lib/modules/flowdock_invite.coffee`. 
1. I need `getRecipient` to return the id out of the callbacks where the id is found, and 
2. I need to wait for that id to come back on line 37 before moving on
